### PR TITLE
FEATURE: Add src and test for three different pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The aim of the pattern is to enable a different way to handle three use case:
 - Create a dynamic algorithm, using a Rule-engine-like approach
 - Refactor of a complex and over-populated switch/case
 
-All the code that falls in these use cases is not compliant with OOP principle and out objective is to make it so, with the help of some SOLID principles.
+All the code that falls in these use cases is not compliant with OOP principle and our objective is to make it so, with the help of some SOLID principles.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The aim of the pattern is to enable a different way to handle three use case:
 - Create a dynamic algorithm, using a Rule-engine-like approach
 - Refactor of a complex and over-populated switch/case
 
-All the code the falls in these use cases is not compliant with OOP principle and out objective is to make it so, with the help of some SOLID principles.
+All the code that falls in these use cases is not compliant with OOP principle and out objective is to make it so, with the help of some SOLID principles.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 Introducing **Pipeline pattern** using functional programming approach.
 
 
-## abstract
+## Abstract
 
-The aim of the pattern is to enable a different way to handle the switch case in the code.
-All the code written using switch is not compliant with OOP principle.
-We wanna have a pattern, allow us, to add new use cases without changing the core code to handle the action related to a possible state.
+The aim of the pattern is to enable a different way to handle three use case:
+- Refactor of a convoluted alghoritm, resembling something similar to the template pattern
+- Create a dynamic algorithm, using a Rule-engine-like approach
+- Refactor of a complex and over-populated switch/case
+
+All the code the falls in these use cases is not compliant with OOP principle and out objective is to make it so, with the help of some SOLID principles.

--- a/src/Contexts/IPatternMatchingContexts.cs
+++ b/src/Contexts/IPatternMatchingContexts.cs
@@ -1,0 +1,6 @@
+﻿namespace PipelineFp.Contexts;
+
+public interface IPatternMatchingContext<out TSelector>
+{
+    TSelector Selector { get; }
+}

--- a/src/Extensions/EitherExtensions.cs
+++ b/src/Extensions/EitherExtensions.cs
@@ -1,0 +1,11 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Extensions;
+
+internal static class EitherExtensions
+{
+    public static async Task<Either<M, R>> BindLeftAsync<L, R, M>(this Task<Either<L, R>> @this, Func<L, Task<Either<M, R>>> onLeft)
+    {
+        return await (await @this).BindLeftAsync(onLeft);
+    }
+}

--- a/src/Extensions/OptionExtensions.cs
+++ b/src/Extensions/OptionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Extensions;
+
+internal static class OptionExtensions
+{
+    internal static async Task<A> OrElse<A>(this Task<Option<A>> @this, Func<A> func)
+        => (await @this).MapNone(func).Unwrap();
+
+    internal static Task<A> OrElse<A>(this Task<Option<A>> @this, A val)
+        => @this.OrElse(() => val);
+}

--- a/src/Patterns/IAsyncOnErrorCallback.cs
+++ b/src/Patterns/IAsyncOnErrorCallback.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Patterns;
+
+public interface IAsyncOnErrorCallback<TError, TContext>
+{
+    Task<Either<TError, TContext>> OnError(TContext context, TError error);
+}

--- a/src/Patterns/IAsyncOnExceptionCallback.cs
+++ b/src/Patterns/IAsyncOnExceptionCallback.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Patterns;
+
+public interface IAsyncOnExceptionCallback<TError, TContext>
+{
+    Task<Either<TError, TContext>> OnException(TContext context, Exception ex);
+}

--- a/src/Patterns/IAsyncPattern.cs
+++ b/src/Patterns/IAsyncPattern.cs
@@ -1,0 +1,9 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Patterns;
+
+public interface IAsyncPattern<TError, TContext, out TSelector>
+{
+    Task<Either<TError, TContext>> Match(TContext context);
+    TSelector Selector { get; }
+}

--- a/src/Patterns/IOnErrorCallback.cs
+++ b/src/Patterns/IOnErrorCallback.cs
@@ -1,0 +1,6 @@
+﻿using TinyFp;
+
+public interface IOnErrorCallback<TError, TContext>
+{
+    Either<TError, TContext> OnError(TContext context, TError error);
+}

--- a/src/Patterns/IOnExceptionCallback.cs
+++ b/src/Patterns/IOnExceptionCallback.cs
@@ -1,0 +1,6 @@
+﻿using TinyFp;
+
+public interface IOnExceptionCallback<TError, TContext>
+{
+    Either<TError, TContext> OnException(TContext context, Exception ex);
+}

--- a/src/Patterns/IPattern.cs
+++ b/src/Patterns/IPattern.cs
@@ -1,0 +1,7 @@
+﻿using TinyFp;
+
+public interface IPattern<TError, TContext, out TSelector>
+{
+    Either<TError, TContext> Match(TContext context);
+    TSelector Selector { get; }
+}

--- a/src/Pipelines/ConditionalPipeline.cs
+++ b/src/Pipelines/ConditionalPipeline.cs
@@ -1,0 +1,79 @@
+﻿using PipelineFp.Steps;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFp.Extensions.EitherExtensions;
+using static TinyFp.Prelude;
+
+namespace PipelineFp.Pipelines;
+
+public class ConditionalPipeline<TContext> : IConditionalPipeline<TContext>
+{
+    private readonly TContext _context;
+
+    private ConditionalPipeline(TContext context)
+    {
+        _context = context;
+    }
+
+    public static IConditionalPipeline<TContext> Given(TContext context)
+        => new ConditionalPipeline<TContext>(context);
+
+    public Either<TError, TContext> Fit<TError>(
+      IEnumerable<IConditionalStep<TError, TContext>> steps)
+        => Fit(steps, _context, [], []);
+
+    public Task<Either<TError, TContext>> Fit<TError>(
+       IEnumerable<IConditionalAsyncStep<TError, TContext>> steps)
+        => Fit(steps, _context, [], []);
+
+    public Task<Either<TError, TContext>> Fit<TError>(
+        IEnumerable<IConditionalAsyncStep<TError, TContext>> steps,
+        IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps)
+        => Fit(steps, _context, onFailSteps, onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(
+        IEnumerable<IConditionalStep<TError, TContext>> steps,
+        IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps)
+        => Fit(steps, _context, onFailSteps, onExceptionSteps);
+
+    private static Either<TError, TContext> Fit<TError>(
+        IEnumerable<IConditionalStep<TError, TContext>> steps,
+        TContext context,
+        IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps)
+        => Try(() => steps
+                    .Fold(Either<TError, TContext>.Right(context),
+                         (state, step) => state
+                                            .Bind(_ => step.ToOption(__ => !__.ExecutionCondition(_))
+                                                           .Map(__ => __.Forward(_))
+                                                           .OrElse(_)))
+                    .BindLeft(error => onFailSteps
+                                      .ToOption(_ => !_.Any())
+                                      .Map(_ => _.Fold(Right<TError, TContext>(context),
+                                                      (state, step) => state.Bind(_ => step.Forward(_, error))))
+                                      .OrElse(error)))
+        .OnFail(ex => onExceptionSteps
+                     .Fold(Right<TError, TContext>(context),
+                          (context, step) => context.Bind(_ => step.Forward(_, ex))));
+
+    private static Task<Either<TError, TContext>> Fit<TError>(
+    IEnumerable<IConditionalAsyncStep<TError, TContext>> steps,
+    TContext context,
+    IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+    IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps)
+    => TryAsync(() => steps
+                      .FoldAsync(Right<TError, TContext>(context),
+                                (state, step) => state.BindAsync(_ => step.ToOption(__ => !__.ExecutionCondition(_))
+                                                                          .Map(__ => __.Forward(_))
+                                                                          .OrElse(state.AsTask())))
+                       .BindLeftAsync(error => onFailSteps
+                                                 .ToOption(_ => !_.Any())
+                                                 .Map(_ => _.FoldAsync(Right<TError, TContext>(context),
+                                                                      (state, step) => state.BindAsync(_ => step.Forward(_, error))))
+                                                 .OrElse(Left<TError, TContext>(error).AsTask())))
+    .OnFail(ex => onExceptionSteps
+                 .FoldAsync(Right<TError, TContext>(context),
+                           (context, step) => context.BindAsync(_ => step.Forward(_, ex))));
+}

--- a/src/Pipelines/IConditionalPipeline.cs
+++ b/src/Pipelines/IConditionalPipeline.cs
@@ -1,0 +1,23 @@
+﻿using PipelineFp.Steps;
+using TinyFp;
+
+namespace PipelineFp.Pipelines;
+
+public interface IConditionalPipeline<TContext>
+{
+    public Task<Either<TError, TContext>> Fit<TError>(
+       IEnumerable<IConditionalAsyncStep<TError, TContext>> steps,
+       IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+       IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(
+      IEnumerable<IConditionalStep<TError, TContext>> steps,
+      IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+      IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(IEnumerable<IConditionalStep<TError, TContext>> steps);
+
+    public Task<Either<TError, TContext>> Fit<TError>(IEnumerable<IConditionalAsyncStep<TError, TContext>> steps);
+}
+
+

--- a/src/Pipelines/IMatchingPipeline.cs
+++ b/src/Pipelines/IMatchingPipeline.cs
@@ -1,0 +1,22 @@
+﻿using PipelineFp.Contexts;
+using PipelineFp.Patterns;
+using TinyFp;
+
+namespace PipelineFp.Pipelines;
+
+public interface IMatchingPipeline<TContext, TSelector> where TContext : IPatternMatchingContext<TSelector>
+{
+    public Either<TError, TContext> Match<TError>(HashSet<IPattern<TError, TContext, TSelector>> patterns);
+
+    public Task<Either<TError, TContext>> Match<TError>(HashSet<IAsyncPattern<TError, TContext, TSelector>> patterns);
+
+    public Task<Either<TError, TContext>> Match<TError>(
+        HashSet<IAsyncPattern<TError, TContext, TSelector>> patterns,
+        HashSet<IAsyncOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IAsyncOnExceptionCallback<TError, TContext>> onExceptionCallbacks);
+
+    public Either<TError, TContext> Match<TError>(
+        HashSet<IPattern<TError, TContext, TSelector>> patterns,
+        HashSet<IOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IOnExceptionCallback<TError, TContext>> onExceptionCallbacks);
+}

--- a/src/Pipelines/IPipeline.cs
+++ b/src/Pipelines/IPipeline.cs
@@ -1,0 +1,21 @@
+﻿using PipelineFp.Steps;
+using TinyFp;
+
+namespace PipelineFp.Pipelines;
+
+public interface IPipeline<TContext>
+{
+    public Task<Either<TError, TContext>> Fit<TError>(
+       IEnumerable<IAsyncStep<TError, TContext>> steps,
+       IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+       IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(
+      IEnumerable<IStep<TError, TContext>> steps,
+      IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+      IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(IEnumerable<IStep<TError, TContext>> steps);
+
+    public Task<Either<TError, TContext>> Fit<TError>(IEnumerable<IAsyncStep<TError, TContext>> steps);
+}

--- a/src/Pipelines/MatchingPipeline.cs
+++ b/src/Pipelines/MatchingPipeline.cs
@@ -1,0 +1,82 @@
+﻿using PipelineFp.Contexts;
+using PipelineFp.Patterns;
+using System.Collections.Immutable;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFp.Extensions.EitherExtensions;
+using static PipelineFp.Extensions.OptionExtensions;
+using static TinyFp.Prelude;
+
+namespace PipelineFp.Pipelines;
+
+public class MatchingPipeline<TContext, TSelector> : IMatchingPipeline<TContext, TSelector>
+                                                     where TContext : IPatternMatchingContext<TSelector>
+{
+    private readonly TContext _context;
+
+    private MatchingPipeline(TContext context)
+    {
+        _context = context;
+    }
+
+    public static IMatchingPipeline<TContext, TSelector> Given(TContext context)
+       => new MatchingPipeline<TContext, TSelector>(context);
+
+    public Either<TError, TContext> Match<TError>(HashSet<IPattern<TError, TContext, TSelector>> patterns)
+        => Match(patterns, _context, [], []);
+
+    public Task<Either<TError, TContext>> Match<TError>(HashSet<IAsyncPattern<TError, TContext, TSelector>> patterns)
+        => Match(patterns, _context, [], []);
+
+    public Task<Either<TError, TContext>> Match<TError>(
+        HashSet<IAsyncPattern<TError, TContext, TSelector>> patterns,
+        HashSet<IAsyncOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IAsyncOnExceptionCallback<TError, TContext>> onExceptionCallbacks)
+        => Match(patterns, _context, onErrorCallbacks, onExceptionCallbacks);
+
+    public Either<TError, TContext> Match<TError>(
+        HashSet<IPattern<TError, TContext, TSelector>> patterns,
+        HashSet<IOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IOnExceptionCallback<TError, TContext>> onExceptionCallbacks)
+        => Match(patterns, _context, onErrorCallbacks, onExceptionCallbacks);
+
+    private static Either<TError, TContext> Match<TError>(
+        HashSet<IPattern<TError, TContext, TSelector>> patterns,
+        TContext context,
+        HashSet<IOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IOnExceptionCallback<TError, TContext>> onExceptionCallbacks)
+        => Try(() => patterns
+                    .ToImmutableDictionary(pattern => pattern.Selector,
+                                           match => match)
+                    .Map(_ => _.GetValueOrDefault(context.Selector))
+                    .Map(_ => _.ToOption()
+                               .Map(_ => _.Match(context))
+                               .OrElse(context))
+                    .BindLeft(error => onErrorCallbacks.ToOption(_ => _.Count == 0)
+                                                       .Map(_ => _.Fold(Right<TError, TContext>(context),
+                                                                       (state, onError) => state.Bind(_ => onError.OnError(_, error))))
+                                                       .OrElse(error)))
+        .OnFail(ex => onExceptionCallbacks
+                      .Fold(Right<TError, TContext>(context),
+                           (state, onException) => state.Bind(_ => onException.OnException(_, ex))));
+
+    private static Task<Either<TError, TContext>> Match<TError>(
+        HashSet<IAsyncPattern<TError, TContext, TSelector>> patterns,
+        TContext context,
+        HashSet<IAsyncOnErrorCallback<TError, TContext>> onErrorCallbacks,
+        HashSet<IAsyncOnExceptionCallback<TError, TContext>> onExceptionCallbacks)
+        => TryAsync(() => patterns
+                        .ToImmutableDictionary(pattern => pattern.Selector,
+                                               match => match)
+                        .Map(_ => _.GetValueOrDefault(context.Selector))
+                        .Map(_ => _.ToOption()
+                                   .MapAsync(_ => _.Match(context))
+                                   .OrElse(context))
+                        .BindLeftAsync(error => onErrorCallbacks.ToOption(_ => _.Count == 0)
+                                                                .Map(_ => _.FoldAsync(Right<TError, TContext>(context),
+                                                                                     (state, onError) => state.BindAsync(_ => onError.OnError(_, error))))
+                                                                .OrElse(Left<TError, TContext>(error).AsTask())))
+          .OnFail(ex => onExceptionCallbacks
+                        .FoldAsync(Right<TError, TContext>(context),
+                                  (state, onException) => state.BindAsync(_ => onException.OnException(_, ex))));
+}

--- a/src/Pipelines/Pipeline.cs
+++ b/src/Pipelines/Pipeline.cs
@@ -1,0 +1,72 @@
+﻿using PipelineFp.Steps;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFp.Extensions.EitherExtensions;
+using static TinyFp.Prelude;
+
+namespace PipelineFp.Pipelines;
+
+public class Pipeline<TContext> : IPipeline<TContext>
+{
+    private readonly TContext _context;
+
+    private Pipeline(TContext context)
+    {
+        _context = context;
+    }
+
+    public static IPipeline<TContext> Given(TContext context)
+        => new Pipeline<TContext>(context);
+
+    public Either<TError, TContext> Fit<TError>(IEnumerable<IStep<TError, TContext>> steps)
+        => Fit(steps, _context, [], []);
+
+    public Task<Either<TError, TContext>> Fit<TError>(IEnumerable<IAsyncStep<TError, TContext>> steps)
+        => Fit(steps, _context, [], []);
+
+    public Task<Either<TError, TContext>> Fit<TError>(
+        IEnumerable<IAsyncStep<TError, TContext>> steps,
+        IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps)
+        => Fit(steps, _context, onFailSteps, onExceptionSteps);
+
+    public Either<TError, TContext> Fit<TError>(
+        IEnumerable<IStep<TError, TContext>> steps,
+        IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps)
+        => Fit(steps, _context, onFailSteps, onExceptionSteps);
+
+    private static Task<Either<TError, TContext>> Fit<TError>(
+        IEnumerable<IAsyncStep<TError, TContext>> steps,
+        TContext context,
+        IEnumerable<IOnErrorAsyncStep<TError, TContext>> onFailSteps,
+        IEnumerable<IOnExceptionAsyncStep<TError, TContext>> onExceptionSteps)
+        => TryAsync(() => steps
+                         .FoldAsync(Right<TError, TContext>(context),
+                                   (state, step) => state.BindAsync(_ => step.Forward(context)))
+                         .BindLeftAsync(error => onFailSteps
+                                                 .ToOption(_ => !_.Any())
+                                                 .Map(_ => _.FoldAsync(Right<TError, TContext>(context),
+                                                                      (state, step) => state.BindAsync(_ => step.Forward(_, error))))
+                                                 .OrElse(Left<TError, TContext>(error).AsTask())))
+        .OnFail(ex => onExceptionSteps
+                     .FoldAsync(Right<TError, TContext>(context),
+                               (state, step) => state.BindAsync(_ => step.Forward(_, ex))));
+
+    private static Either<TError, TContext> Fit<TError>(
+       IEnumerable<IStep<TError, TContext>> steps,
+       TContext context,
+       IEnumerable<IOnErrorStep<TError, TContext>> onFailSteps,
+       IEnumerable<IOnExceptionStep<TError, TContext>> onExceptionSteps)
+       => Try(() => steps
+                   .Fold(Right<TError, TContext>(context),
+                        (state, step) => state.Bind(_ => step.Forward(_)))
+                   .BindLeft(error => onFailSteps
+                                      .ToOption(_ => !_.Any())
+                                      .Map(_ => _.Fold(Right<TError, TContext>(context),
+                                                      (state, step) => state.Bind(_ => step.Forward(_, error))))
+                                      .OrElse(error)))
+       .OnFail(ex => onExceptionSteps
+                    .Fold(Right<TError, TContext>(context),
+                         (state, step) => state.Bind(_ => step.Forward(_, ex))));
+}

--- a/src/Steps/IAsyncStep.cs
+++ b/src/Steps/IAsyncStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IAsyncStep<TError, TContext>
+{
+    Task<Either<TError, TContext>> Forward(TContext context);
+}

--- a/src/Steps/IConditionalAsyncStep.cs
+++ b/src/Steps/IConditionalAsyncStep.cs
@@ -1,0 +1,6 @@
+﻿namespace PipelineFp.Steps;
+
+public interface IConditionalAsyncStep<TError, TContext> : IAsyncStep<TError, TContext>
+{
+    Predicate<TContext> ExecutionCondition { get; }
+}

--- a/src/Steps/IConditionalStep.cs
+++ b/src/Steps/IConditionalStep.cs
@@ -1,0 +1,6 @@
+﻿namespace PipelineFp.Steps;
+
+public interface IConditionalStep<TError, TContext> : IStep<TError, TContext>
+{
+    Predicate<TContext> ExecutionCondition { get; }
+}

--- a/src/Steps/IOnErrorAsyncStep.cs
+++ b/src/Steps/IOnErrorAsyncStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IOnErrorAsyncStep<TError, TContext>
+{
+    Task<Either<TError, TContext>> Forward(TContext context, TError error);
+}

--- a/src/Steps/IOnErrorStep.cs
+++ b/src/Steps/IOnErrorStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IOnErrorStep<TError, TContext>
+{
+    Either<TError, TContext> Forward(TContext context, TError error);
+}

--- a/src/Steps/IOnExceptionAsyncStep.cs
+++ b/src/Steps/IOnExceptionAsyncStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IOnExceptionAsyncStep<TError, TContext>
+{
+    Task<Either<TError, TContext>> Forward(TContext context, Exception ex);
+}

--- a/src/Steps/IOnExceptionStep.cs
+++ b/src/Steps/IOnExceptionStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IOnExceptionStep<TError, TContext>
+{
+    Either<TError, TContext> Forward(TContext context, Exception ex);
+}

--- a/src/Steps/IStep.cs
+++ b/src/Steps/IStep.cs
@@ -1,0 +1,8 @@
+﻿using TinyFp;
+
+namespace PipelineFp.Steps;
+
+public interface IStep<TError, TContext>
+{
+    Either<TError, TContext> Forward(TContext context);
+}

--- a/src/pipeline-fp.csproj
+++ b/src/pipeline-fp.csproj
@@ -12,4 +12,8 @@
 		<PackageTags>Functional Programming</PackageTags>
 	</PropertyGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="tiny-fp" Version="2.0.0" />
+	</ItemGroup>
+
 </Project>

--- a/test/Builder/AsyncPipeline/BuiderAsyncFirstStep.cs
+++ b/test/Builder/AsyncPipeline/BuiderAsyncFirstStep.cs
@@ -1,0 +1,22 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncFirstStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => Either<Error, BuilderAsyncStepsContext>.Right(context)
+        .MapAsync(UpdateContext);
+
+    private static Task<BuilderAsyncStepsContext> UpdateContext(BuilderAsyncStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.First))
+        .Map(_ => _.With([First]))
+        .OrElse(context)
+        .AsTask();
+}

--- a/test/Builder/AsyncPipeline/BuilderAsyncJoinStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncJoinStep.cs
@@ -1,0 +1,22 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncJoinStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => Either<Error, BuilderAsyncStepsContext>.Right(context)
+        .MapAsync(UpdateContext);
+
+    private static Task<BuilderAsyncStepsContext> UpdateContext(BuilderAsyncStepsContext context)
+        => context
+        .ToOption()
+        .Map(_ => _.With(string.Join(Joiner, _.Steps)))
+        .OrElse(context)
+        .AsTask();
+}
+

--- a/test/Builder/AsyncPipeline/BuilderAsyncSecondStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncSecondStep.cs
@@ -1,0 +1,23 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncSecondStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => Either<Error, BuilderAsyncStepsContext>.Right(context)
+        .MapAsync(UpdateContext);
+
+    private static Task<BuilderAsyncStepsContext> UpdateContext(BuilderAsyncStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.Second))
+        .Map(_ => _.With([Second]))
+        .OrElse(context)
+        .AsTask();
+}
+

--- a/test/Builder/AsyncPipeline/BuilderAsyncStepsContext.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncStepsContext.cs
@@ -1,0 +1,33 @@
+﻿using PipelineFpTest.Switch;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncStepsContext
+{
+    internal BuilderStep InputStep { get; private set; }
+    internal string[] Steps { get; private set; }
+    internal string Result { get; private set; }
+
+    private BuilderAsyncStepsContext(
+        BuilderStep inputStep,
+        string[] steps,
+        string result)
+    {
+        InputStep = inputStep;
+        Steps = steps;
+        Result = result;
+    }
+
+    internal static BuilderAsyncStepsContext With(BuilderStep inputStep)
+        => new(inputStep,
+            [],
+            string.Empty);
+
+    internal BuilderAsyncStepsContext With(string[] steps)
+        => this.Tee(_ => _.Steps = [.. Steps, .. steps]);
+
+    internal BuilderAsyncStepsContext With(string result)
+        => this.Tee(_ => _.Result = result);
+}
+

--- a/test/Builder/AsyncPipeline/BuilderAsyncTestErrorStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncTestErrorStep.cs
@@ -1,0 +1,15 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncTestErrorStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => Either<Error, BuilderAsyncStepsContext>.Left(new Error
+        {
+            Message = "TestError"
+        }).AsTask();
+}
+

--- a/test/Builder/AsyncPipeline/BuilderAsyncTestExceptionStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncTestExceptionStep.cs
@@ -1,0 +1,12 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncTestExceptionStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => throw new Exception("Exception");
+}
+

--- a/test/Builder/AsyncPipeline/BuilderAsyncThirdStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderAsyncThirdStep.cs
@@ -1,0 +1,23 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderAsyncThirdStep : IAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context)
+        => Either<Error, BuilderAsyncStepsContext>.Right(context)
+        .MapAsync(UpdateContext);
+
+    private static Task<BuilderAsyncStepsContext> UpdateContext(BuilderAsyncStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.Third))
+        .Map(_ => _.With([Third]))
+        .OrElse(context)
+        .AsTask();
+}
+

--- a/test/Builder/AsyncPipeline/BuilderOnErrorAsyncStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderOnErrorAsyncStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderOnErrorAsyncStep : IOnErrorAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context, Error error)
+        => context.With($"Error Handled: {error.Message}. Executed steps: {string.Join(Joiner, context.Steps)}")
+        .Map(Either<Error, BuilderAsyncStepsContext>.Right)
+        .AsTask();
+}
+

--- a/test/Builder/AsyncPipeline/BuilderOnExceptionAsyncStep.cs
+++ b/test/Builder/AsyncPipeline/BuilderOnExceptionAsyncStep.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.AsyncPipeline;
+
+internal class BuilderOnExceptionAsyncStep : IOnExceptionAsyncStep<Error, BuilderAsyncStepsContext>
+{
+    public Task<Either<Error, BuilderAsyncStepsContext>> Forward(BuilderAsyncStepsContext context, Exception ex)
+       => Either<Error, BuilderAsyncStepsContext>.Right(context)
+       .MapAsync(_ => UpdateContext(_, ex));
+
+    private static Task<BuilderAsyncStepsContext> UpdateContext(BuilderAsyncStepsContext context, Exception ex)
+    => context.With($"Exception Handled: {ex.Message}. Executed steps: {string.Join(Joiner, context.Steps)}")
+        .AsTask();
+}
+

--- a/test/Builder/BuilderUseCase.cs
+++ b/test/Builder/BuilderUseCase.cs
@@ -1,4 +1,9 @@
+using PipelineFp.Pipelines;
+using PipelineFpTest.Builder.AsyncPipeline;
+using PipelineFpTest.Builder.Pipeline;
 using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
 
 namespace PipelineFpTest.Builder;
 
@@ -8,11 +13,133 @@ public class BuilderUseCase
     {
         string[] steps = [];
         if (switchStep.HasFlag(BuilderStep.First))
-            steps = steps.Append("First").ToArray();
+            steps = [.. steps, "First"];
         if (switchStep.HasFlag(BuilderStep.Second))
-            steps = steps.Append("Second").ToArray();
+            steps = [.. steps, "Second"];
         if (switchStep.HasFlag(BuilderStep.Third))
-            steps = steps.Append("Third").ToArray();
+            steps = [.. steps, "Third"];
         return string.Join(",", steps);
     }
+
+    public static Task<string> ResolveUsingAsyncPipeline(BuilderStep initialValue)
+        => BuilderAsyncStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderAsyncStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderAsyncFirstStep(),
+                           new BuilderAsyncSecondStep(),
+                           new BuilderAsyncThirdStep(),
+                           new BuilderAsyncJoinStep()]))
+        .MatchAsync(_ => _.Result,
+                    _ => string.Empty);
+
+    public static Task<string> ResolveUsingAsyncPipelineInCaseOfError(BuilderStep initialValue)
+        => BuilderAsyncStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderAsyncStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderAsyncFirstStep(),
+                           new BuilderAsyncSecondStep(),
+                           new BuilderAsyncTestErrorStep(),
+                           new BuilderAsyncThirdStep(),
+                           new BuilderAsyncJoinStep()],
+                           [new BuilderOnErrorAsyncStep()],
+                           []))
+        .MatchAsync(_ => _.Result,
+                    _ => string.Empty);
+
+    public static Task<string> ResolveUsingAsyncPipelineInCaseOfErrorWithoutErrorSteps(BuilderStep initialValue)
+        => BuilderAsyncStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderAsyncStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderAsyncFirstStep(),
+                           new BuilderAsyncSecondStep(),
+                           new BuilderAsyncTestErrorStep(),
+                           new BuilderAsyncThirdStep(),
+                           new BuilderAsyncJoinStep()],
+                           [],
+                           []))
+        .MatchAsync(_ => _.Result,
+                    _ => _.Message);
+
+    public static Task<string> ResolveUsingAsyncPipelineInCaseOfException(BuilderStep initialValue)
+        => BuilderAsyncStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderAsyncStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderAsyncFirstStep(),
+                           new BuilderAsyncSecondStep(),
+                           new BuilderAsyncTestExceptionStep(),
+                           new BuilderAsyncThirdStep(),
+                           new BuilderAsyncJoinStep()],
+                           [new BuilderOnErrorAsyncStep()],
+                           [new BuilderOnExceptionAsyncStep()]))
+        .MatchAsync(_ => _.Result,
+                    _ => string.Empty);
+
+    public static string ResolveUsingPipeline(BuilderStep initialValue)
+       => BuilderStepsContext
+       .With(initialValue)
+       .Map(context => Pipeline<BuilderStepsContext>
+                      .Given(context)
+                      .Fit([
+                          new BuilderFirstStep(),
+                          new BuilderSecondStep(),
+                          new BuilderThirdStep(),
+                          new BuilderJoinStep()]))
+       .Match(_ => _.Result,
+              _ => string.Empty);
+
+    public static string ResolveUsingPipelineInCaseOfError(BuilderStep initialValue)
+        => BuilderStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderFirstStep(),
+                           new BuilderSecondStep(),
+                           new BuilderTestErrorStep(),
+                           new BuilderThirdStep(),
+                           new BuilderJoinStep()],
+                           [new BuilderOnErrorStep()],
+                           []))
+        .Match(_ => _.Result,
+               _ => string.Empty);
+
+    public static string ResolveUsingPipelineInCaseOfErrorWithoutErrorSteps(BuilderStep initialValue)
+        => BuilderStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderFirstStep(),
+                           new BuilderSecondStep(),
+                           new BuilderTestErrorStep(),
+                           new BuilderThirdStep(),
+                           new BuilderJoinStep()],
+                           [],
+                           []))
+        .Match(_ => _.Result,
+               _ => _.Message);
+
+    public static string ResolveUsingPipelineInCaseOfException(BuilderStep initialValue)
+        => BuilderStepsContext
+        .With(initialValue)
+        .Map(context => Pipeline<BuilderStepsContext>
+                       .Given(context)
+                       .Fit([
+                           new BuilderFirstStep(),
+                           new BuilderSecondStep(),
+                           new BuilderTestExceptionStep(),
+                           new BuilderThirdStep(),
+                           new BuilderJoinStep()],
+                           [new BuilderOnErrorStep()],
+                           [new BuilderOnExceptionStep()]))
+        .Match(_ => _.Result,
+               _ => string.Empty);
 }

--- a/test/Builder/Constants.cs
+++ b/test/Builder/Constants.cs
@@ -1,0 +1,12 @@
+﻿namespace PipelineFpTest.Builder;
+
+internal static class Constants
+{
+    internal static class Steps
+    {
+        internal const string First = "First",
+                              Second = "Second",
+                              Third = "Third",
+                              Joiner = ",";
+    }
+}

--- a/test/Builder/Pipeline/BuilderFirstStep.cs
+++ b/test/Builder/Pipeline/BuilderFirstStep.cs
@@ -1,0 +1,21 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderFirstStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => Either<Error, BuilderStepsContext>.Right(context)
+        .Map(UpdateContext);
+
+    private static BuilderStepsContext UpdateContext(BuilderStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.First))
+        .Map(_ => _.With([First]))
+        .OrElse(context);
+}

--- a/test/Builder/Pipeline/BuilderJoinStep.cs
+++ b/test/Builder/Pipeline/BuilderJoinStep.cs
@@ -1,0 +1,20 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderJoinStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => Either<Error, BuilderStepsContext>.Right(context)
+        .Map(UpdateContext);
+
+    private static BuilderStepsContext UpdateContext(BuilderStepsContext context)
+        => context
+        .ToOption()
+        .Map(_ => _.With(string.Join(Joiner, _.Steps)))
+        .OrElse(context);
+}

--- a/test/Builder/Pipeline/BuilderOnErrorStep.cs
+++ b/test/Builder/Pipeline/BuilderOnErrorStep.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderOnErrorStep : IOnErrorStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context, Error error)
+        => context.With($"Error Handled: {error.Message}. Executed steps: {string.Join(Joiner, context.Steps)}")
+         .Map(Either<Error, BuilderStepsContext>.Right);
+}

--- a/test/Builder/Pipeline/BuilderOnExceptionStep.cs
+++ b/test/Builder/Pipeline/BuilderOnExceptionStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderOnExceptionStep : IOnExceptionStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context, Exception ex)
+       => Either<Error, BuilderStepsContext>.Right(context)
+    .Map(_ => UpdateContext(_, ex));
+
+    private static BuilderStepsContext UpdateContext(BuilderStepsContext context, Exception ex)
+    => context.With($"Exception Handled: {ex.Message}. Executed steps: {string.Join(Joiner, context.Steps)}");
+}

--- a/test/Builder/Pipeline/BuilderSecondStep.cs
+++ b/test/Builder/Pipeline/BuilderSecondStep.cs
@@ -1,0 +1,21 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderSecondStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => Either<Error, BuilderStepsContext>.Right(context)
+        .Map(UpdateContext);
+
+    private static BuilderStepsContext UpdateContext(BuilderStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.Second))
+        .Map(_ => _.With([Second]))
+        .OrElse(context);
+}

--- a/test/Builder/Pipeline/BuilderStepsContext.cs
+++ b/test/Builder/Pipeline/BuilderStepsContext.cs
@@ -1,0 +1,32 @@
+﻿using PipelineFpTest.Switch;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderStepsContext
+{
+    internal BuilderStep InputStep { get; private set; }
+    internal string[] Steps { get; private set; }
+    internal string Result { get; private set; }
+
+    private BuilderStepsContext(
+        BuilderStep inputStep,
+        string[] steps,
+        string result)
+    {
+        InputStep = inputStep;
+        Steps = steps;
+        Result = result;
+    }
+
+    internal static BuilderStepsContext With(BuilderStep inputStep)
+        => new(inputStep,
+            [],
+            string.Empty);
+
+    internal BuilderStepsContext With(string[] steps)
+        => this.Tee(_ => _.Steps = [.. Steps, .. steps]);
+
+    internal BuilderStepsContext With(string result)
+        => this.Tee(_ => _.Result = result);
+}

--- a/test/Builder/Pipeline/BuilderTestErrorStep.cs
+++ b/test/Builder/Pipeline/BuilderTestErrorStep.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderTestErrorStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => Either<Error, BuilderStepsContext>.Left(new Error
+        {
+            Message = "TestError"
+        });
+}

--- a/test/Builder/Pipeline/BuilderTestExceptionStep.cs
+++ b/test/Builder/Pipeline/BuilderTestExceptionStep.cs
@@ -1,0 +1,11 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderTestExceptionStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => throw new Exception("Exception");
+}

--- a/test/Builder/Pipeline/BuilderThirdStep.cs
+++ b/test/Builder/Pipeline/BuilderThirdStep.cs
@@ -1,0 +1,21 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Builder.Constants.Steps;
+
+namespace PipelineFpTest.Builder.Pipeline;
+
+internal class BuilderThirdStep : IStep<Error, BuilderStepsContext>
+{
+    public Either<Error, BuilderStepsContext> Forward(BuilderStepsContext context)
+        => Either<Error, BuilderStepsContext>.Right(context)
+        .Map(UpdateContext);
+
+    private static BuilderStepsContext UpdateContext(BuilderStepsContext context)
+        => context
+        .ToOption(_ => !_.InputStep.HasFlag(BuilderStep.Third))
+        .Map(_ => _.With([Third]))
+        .OrElse(context);
+}

--- a/test/DataTypes/Error.cs
+++ b/test/DataTypes/Error.cs
@@ -1,0 +1,6 @@
+﻿namespace PipelineFpTest.DataTypes;
+
+internal class Error
+{
+    public string Message { get; set; }
+}

--- a/test/Strategy/AsyncMatchingPipeline/AsyncFirstStrategy.cs
+++ b/test/Strategy/AsyncMatchingPipeline/AsyncFirstStrategy.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.AsyncMatchingPipeline;
+
+internal class AsyncFirstStrategy : IAsyncPattern<Error, StrategyContext, string>
+{
+    public string Selector => "first";
+
+    public Task<Either<Error, StrategyContext>> Match(StrategyContext context)
+        => TinyFp.Prelude.TryAsync(() => context.Params[0]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>)
+                                   .AsTask())
+        .OnFail(new Error { Message = "First strategy error" });
+}

--- a/test/Strategy/AsyncMatchingPipeline/AsyncSecondStrategy.cs
+++ b/test/Strategy/AsyncMatchingPipeline/AsyncSecondStrategy.cs
@@ -1,0 +1,19 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.AsyncMatchingPipeline;
+
+internal class AsyncSecondStrategy : IAsyncPattern<Error, StrategyContext, string>
+{
+    public string Selector => "second";
+
+    public Task<Either<Error, StrategyContext>> Match(StrategyContext context)
+        => TinyFp.Prelude.TryAsync(() => context.Params[1]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>)
+                                   .AsTask())
+        .OnFail(new Error { Message = "Second strategy error" });
+}
+

--- a/test/Strategy/AsyncMatchingPipeline/AsyncThirdStrategy.cs
+++ b/test/Strategy/AsyncMatchingPipeline/AsyncThirdStrategy.cs
@@ -1,0 +1,19 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.AsyncMatchingPipeline;
+
+internal class AsyncThirdStrategy : IAsyncPattern<Error, StrategyContext, string>
+{
+    public string Selector => "third";
+
+    public Task<Either<Error, StrategyContext>> Match(StrategyContext context)
+        => TinyFp.Prelude.TryAsync(() => context.Params[2]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>)
+                                   .AsTask())
+        .OnFail(new Error { Message = "Third strategy error" });
+}
+

--- a/test/Strategy/IStrategy.cs
+++ b/test/Strategy/IStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace PipelineFpTest.Strategy;
+
+internal interface IStrategy
+{
+    string Act(params string[] actedUpon);
+}
+

--- a/test/Strategy/MatchingPipeline/FirstStrategy.cs
+++ b/test/Strategy/MatchingPipeline/FirstStrategy.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.MatchingPipeline;
+internal class FirstStrategy : IPattern<Error, StrategyContext, string>
+{
+    public string Selector => "first";
+
+    public Either<Error, StrategyContext> Match(StrategyContext context)
+        => TinyFp.Prelude.Try(() => context.Params[0]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>))
+        .OnFail(new Error { Message = "First strategy error" });
+}
+

--- a/test/Strategy/MatchingPipeline/SecondStrategy.cs
+++ b/test/Strategy/MatchingPipeline/SecondStrategy.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.MatchingPipeline;
+
+internal class SecondStrategy : IPattern<Error, StrategyContext, string>
+{
+    public string Selector => "second";
+
+    public Either<Error, StrategyContext> Match(StrategyContext context)
+        => TinyFp.Prelude.Try(() => context.Params[1]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>))
+        .OnFail(new Error { Message = "Second strategy error" });
+}
+

--- a/test/Strategy/MatchingPipeline/ThirdStrategy.cs
+++ b/test/Strategy/MatchingPipeline/ThirdStrategy.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy.MatchingPipeline;
+
+internal class ThirdStrategy : IPattern<Error, StrategyContext, string>
+{
+    public string Selector => "third";
+
+    public Either<Error, StrategyContext> Match(StrategyContext context)
+        => TinyFp.Prelude.Try(() => context.Params[2]
+                                   .Map(context.WithResult)
+                                   .Map(TinyFp.Prelude.Right<Error, StrategyContext>))
+        .OnFail(new Error { Message = "Third strategy error" });
+}
+

--- a/test/Strategy/StrategyContext.cs
+++ b/test/Strategy/StrategyContext.cs
@@ -1,0 +1,31 @@
+﻿using PipelineFp.Contexts;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy;
+
+internal class StrategyContext : IPatternMatchingContext<string>
+{
+    public string Selector { get; }
+    internal string Result { get; private set; }
+    internal string[] Params { get; private set; }
+
+    private StrategyContext(
+        string inputSelector,
+        string result)
+    {
+        Selector = inputSelector;
+        Result = result;
+        Params = [];
+    }
+
+    internal static StrategyContext With(string inputSelector)
+        => new(inputSelector,
+            string.Empty);
+
+    internal StrategyContext WithParams(params string[] @params)
+        => this.Tee(_ => _.Params = @params);
+
+    internal StrategyContext WithResult(string result)
+        => this.Tee(_ => _.Result = result);
+}
+

--- a/test/Strategy/StrategyUseCase.cs
+++ b/test/Strategy/StrategyUseCase.cs
@@ -1,0 +1,48 @@
+﻿using PipelineFp.Patterns;
+using PipelineFp.Pipelines;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Strategy.AsyncMatchingPipeline;
+using PipelineFpTest.Strategy.MatchingPipeline;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Strategy;
+
+internal static class StrategyUseCase
+{
+    public static string ResolveUsingPatternMatching(string selector, string[] @params)
+      => new HashSet<IPattern<Error, StrategyContext, string>>
+      {
+            new FirstStrategy(),
+            new SecondStrategy(),
+            new ThirdStrategy(),
+
+      }
+      .Map(steps => StrategyContext
+                    .With(selector)
+                    .WithParams(@params)
+                    .Map(context => MatchingPipeline<StrategyContext, string>
+                                   .Given(context)
+                                   .Match(steps, [], [])))
+      .Match(_ => _.Result,
+             _ => _.Message);
+
+    public static Task<string> ResolveUsingAsyncPatternMatching(string selector, string[] @params)
+      => new HashSet<IAsyncPattern<Error, StrategyContext, string>>
+      {
+            new AsyncFirstStrategy(),
+            new AsyncSecondStrategy(),
+            new AsyncThirdStrategy(),
+
+      }
+      .Map(steps => StrategyContext
+                    .With(selector)
+                    .WithParams(@params)
+                    .Map(context => MatchingPipeline<StrategyContext, string>
+                                   .Given(context)
+                                   .Match(steps, [], [])))
+      .MatchAsync(_ => _.Result,
+                  _ => _.Message);
+
+}
+

--- a/test/Switch/AsyncMatchingPipeline/SwitchAsyncOnError.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchAsyncOnError.cs
@@ -1,0 +1,11 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchAsyncOnError : IAsyncOnErrorCallback<Error, SwitchPatternAsyncContext>
+{
+    public Task<Either<Error, SwitchPatternAsyncContext>> OnError(SwitchPatternAsyncContext context, Error error)
+        => Either<Error, SwitchPatternAsyncContext>.Right(context.With("Error")).AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchAsyncOnException.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchAsyncOnException.cs
@@ -1,0 +1,11 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchAsyncOnException : IAsyncOnExceptionCallback<Error, SwitchPatternAsyncContext>
+{
+    public Task<Either<Error, SwitchPatternAsyncContext>> OnException(SwitchPatternAsyncContext context, Exception ex)
+        => Either<Error, SwitchPatternAsyncContext>.Right(context.With(ex.Message)).AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchEastAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchEastAsyncPattern.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchEastAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.East;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => context.With("East")
+        .Map(Either<Error, SwitchPatternAsyncContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchErrorAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchErrorAsyncPattern.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchErrorAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.Error;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => Either<Error, SwitchPatternAsyncContext>.Left(new Error
+        {
+            Message = "Error"
+        })
+        .AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchExceptionAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchExceptionAsyncPattern.cs
@@ -1,0 +1,13 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchExceptionAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.Exception;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => throw new Exception("Exception");
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchNoneAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchNoneAsyncPattern.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchNoneAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.None;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => context.With("None")
+        .Map(Either<Error, SwitchPatternAsyncContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchNorthAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchNorthAsyncPattern.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchNorthAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.North;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => context.With("North")
+        .Map(Either<Error, SwitchPatternAsyncContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchPatternAsyncContext.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchPatternAsyncContext.cs
@@ -1,0 +1,23 @@
+﻿using PipelineFp.Contexts;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchPatternAsyncContext : IPatternMatchingContext<SwitchSelector>
+{
+    public SwitchSelector Selector { get; }
+    internal string Result { get; }
+
+    private SwitchPatternAsyncContext(SwitchSelector selector,
+        string result)
+    {
+        Result = result;
+        Selector = selector;
+    }
+    internal static SwitchPatternAsyncContext With(SwitchSelector selector)
+        => new(selector,
+            string.Empty);
+
+    internal SwitchPatternAsyncContext With(string result)
+        => new(Selector,
+            result);
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchSouthAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchSouthAsyncPattern.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchSouthAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.South;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => context.With("South")
+        .Map(Either<Error, SwitchPatternAsyncContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/AsyncMatchingPipeline/SwitchWestAsyncPattern.cs
+++ b/test/Switch/AsyncMatchingPipeline/SwitchWestAsyncPattern.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Patterns;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.AsyncMatchingPipeline;
+
+internal class SwitchWestAsyncPattern : IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.West;
+
+    public Task<Either<Error, SwitchPatternAsyncContext>> Match(SwitchPatternAsyncContext context)
+        => context.With("West")
+        .Map(Either<Error, SwitchPatternAsyncContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/ConditionalAsyncPipeline/SwitchEastConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchEastConditionalAsyncStep.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchEastConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.East;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => context.With(EastSelector)
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}

--- a/test/Switch/ConditionalAsyncPipeline/SwitchErrorConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchErrorConditionalAsyncStep.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchErrorConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => true;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => TinyFp.Prelude.Left<Error, SwitchContext>(new Error
+        {
+            Message = "Error"
+        }).AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchExceptionConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchExceptionConditionalAsyncStep.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchExceptionConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => true;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => throw new Exception("Exception");
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchNoneConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchNoneConditionalAsyncStep.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchNoneConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.None;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => context.With(NoneSelector)
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchNorthConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchNorthConditionalAsyncStep.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchNorthConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.North;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => context.With(NorthSelector)
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchOnErrorAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchOnErrorAsyncStep.cs
@@ -1,0 +1,15 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchOnErrorAsyncStep : IOnErrorAsyncStep<Error, SwitchContext>
+{
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context, Error error)
+        => context.With($"Error Handled: {error.Message}")
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchOnExceptionAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchOnExceptionAsyncStep.cs
@@ -1,0 +1,17 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchOnExceptionAsyncStep : IOnExceptionAsyncStep<Error, SwitchContext>
+{
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context, Exception ex)
+       => Either<Error, SwitchContext>.Right(context)
+       .MapAsync(_ => UpdateContext(_, ex));
+
+    private static Task<SwitchContext> UpdateContext(SwitchContext context, Exception ex)
+    => context.With($"Exception Handled: {ex.Message}")
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchSouthConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchSouthConditionalAsyncStep.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchSouthConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.South;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => context.With(SouthSelector)
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalAsyncPipeline/SwitchWestConditionalAsyncStep.cs
+++ b/test/Switch/ConditionalAsyncPipeline/SwitchWestConditionalAsyncStep.cs
@@ -1,0 +1,18 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalAsyncPipeline;
+
+internal class SwitchWestConditionalAsyncStep : IConditionalAsyncStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.West;
+
+    public Task<Either<Error, SwitchContext>> Forward(SwitchContext context)
+        => context.With(WestSelector)
+        .Map(Either<Error, SwitchContext>.Right)
+        .AsTask();
+}
+

--- a/test/Switch/ConditionalPipeline/SwitchEastConditionalStep.cs
+++ b/test/Switch/ConditionalPipeline/SwitchEastConditionalStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalPipeline;
+
+internal class SwitchEastConditionalStep : IConditionalStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.East;
+
+    public Either<Error, SwitchContext> Forward(SwitchContext context)
+        => context.With(EastSelector)
+        .Map(Either<Error, SwitchContext>.Right);
+}

--- a/test/Switch/ConditionalPipeline/SwitchNoneConditionalStep.cs
+++ b/test/Switch/ConditionalPipeline/SwitchNoneConditionalStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalPipeline;
+
+internal class SwitchNoneConditionalStep : IConditionalStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.None;
+
+    public Either<Error, SwitchContext> Forward(SwitchContext context)
+        => context.With(NoneSelector)
+        .Map(Either<Error, SwitchContext>.Right);
+}

--- a/test/Switch/ConditionalPipeline/SwitchNorthConditionalStep.cs
+++ b/test/Switch/ConditionalPipeline/SwitchNorthConditionalStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalPipeline;
+
+internal class SwitchNorthConditionalStep : IConditionalStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.North;
+
+    public Either<Error, SwitchContext> Forward(SwitchContext context)
+        => context.With(NorthSelector)
+        .Map(Either<Error, SwitchContext>.Right);
+}

--- a/test/Switch/ConditionalPipeline/SwitchSouthConditionalStep.cs
+++ b/test/Switch/ConditionalPipeline/SwitchSouthConditionalStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalPipeline;
+
+internal class SwitchSouthConditionalStep : IConditionalStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.South;
+
+    public Either<Error, SwitchContext> Forward(SwitchContext context)
+        => context.With(SouthSelector)
+        .Map(Either<Error, SwitchContext>.Right);
+}

--- a/test/Switch/ConditionalPipeline/SwitchWestConditionalStep.cs
+++ b/test/Switch/ConditionalPipeline/SwitchWestConditionalStep.cs
@@ -1,0 +1,16 @@
+﻿using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+using static PipelineFpTest.Switch.Constants.Selectors;
+
+namespace PipelineFpTest.Switch.ConditionalPipeline;
+
+internal class SwitchWestConditionalStep : IConditionalStep<Error, SwitchContext>
+{
+    public Predicate<SwitchContext> ExecutionCondition => context => context.InputSelector == SwitchSelector.West;
+
+    public Either<Error, SwitchContext> Forward(SwitchContext context)
+        => context.With(WestSelector)
+        .Map(Either<Error, SwitchContext>.Right);
+}

--- a/test/Switch/Constant.cs
+++ b/test/Switch/Constant.cs
@@ -1,0 +1,13 @@
+﻿namespace PipelineFpTest.Switch;
+
+internal static class Constants
+{
+    internal static class Selectors
+    {
+        internal const string NoneSelector = "None selector";
+        internal const string NorthSelector = "North selector";
+        internal const string SouthSelector = "South selector";
+        internal const string WestSelector = "West selector";
+        internal const string EastSelector = "East selector";
+    }
+}

--- a/test/Switch/MatchingPipeline/SwitchEastPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchEastPattern.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchEastPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.East;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => context.With("East")
+        .Map(Either<Error, SwitchPatternContext>.Right);
+}

--- a/test/Switch/MatchingPipeline/SwitchErrorPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchErrorPattern.cs
@@ -1,0 +1,15 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchErrorPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.Error;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => Either<Error, SwitchPatternContext>.Left(new Error
+        {
+            Message = "Error"
+        });
+}

--- a/test/Switch/MatchingPipeline/SwitchExceptionPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchExceptionPattern.cs
@@ -1,0 +1,12 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchExceptionPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.Exception;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => throw new Exception("Exception");
+}

--- a/test/Switch/MatchingPipeline/SwitchNonePattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchNonePattern.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchNonePattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.None;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => context.With("None")
+        .Map(Either<Error, SwitchPatternContext>.Right);
+}

--- a/test/Switch/MatchingPipeline/SwitchNorthPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchNorthPattern.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchNorthPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.North;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => context.With("North")
+        .Map(Either<Error, SwitchPatternContext>.Right);
+}

--- a/test/Switch/MatchingPipeline/SwitchOnError.cs
+++ b/test/Switch/MatchingPipeline/SwitchOnError.cs
@@ -1,0 +1,10 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchOnError : IOnErrorCallback<Error, SwitchPatternContext>
+{
+    public Either<Error, SwitchPatternContext> OnError(SwitchPatternContext context, Error error)
+        => context.With("Error");
+}

--- a/test/Switch/MatchingPipeline/SwitchOnException.cs
+++ b/test/Switch/MatchingPipeline/SwitchOnException.cs
@@ -1,0 +1,10 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchOnException : IOnExceptionCallback<Error, SwitchPatternContext>
+{
+    public Either<Error, SwitchPatternContext> OnException(SwitchPatternContext context, Exception ex)
+        => context.With(ex.Message);
+}

--- a/test/Switch/MatchingPipeline/SwitchPatternContext.cs
+++ b/test/Switch/MatchingPipeline/SwitchPatternContext.cs
@@ -1,0 +1,23 @@
+﻿using PipelineFp.Contexts;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchPatternContext : IPatternMatchingContext<SwitchSelector>
+{
+    public SwitchSelector Selector { get; }
+    internal string Result { get; private set; }
+
+    private SwitchPatternContext(SwitchSelector selector,
+        string result)
+    {
+        Result = result;
+        Selector = selector;
+    }
+    internal static SwitchPatternContext With(SwitchSelector selector)
+        => new(selector,
+            string.Empty);
+
+    internal SwitchPatternContext With(string result)
+        => this.Tee(_ => _.Result = result);
+}

--- a/test/Switch/MatchingPipeline/SwitchSouthPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchSouthPattern.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchSouthPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.South;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => context.With("South")
+        .Map(Either<Error, SwitchPatternContext>.Right);
+}

--- a/test/Switch/MatchingPipeline/SwitchWestPattern.cs
+++ b/test/Switch/MatchingPipeline/SwitchWestPattern.cs
@@ -1,0 +1,14 @@
+﻿using PipelineFpTest.DataTypes;
+using TinyFp;
+using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch.MatchingPipeline;
+
+internal class SwitchWestPattern : IPattern<Error, SwitchPatternContext, SwitchSelector>
+{
+    public SwitchSelector Selector => SwitchSelector.West;
+
+    public Either<Error, SwitchPatternContext> Match(SwitchPatternContext context)
+        => context.With("West")
+        .Map(Either<Error, SwitchPatternContext>.Right);
+}

--- a/test/Switch/SwitchContext.cs
+++ b/test/Switch/SwitchContext.cs
@@ -1,0 +1,24 @@
+﻿using TinyFp.Extensions;
+
+namespace PipelineFpTest.Switch;
+
+internal class SwitchContext
+{
+    internal SwitchSelector InputSelector { get; }
+    internal string Result { get; private set; }
+
+    private SwitchContext(
+        SwitchSelector inputSelector,
+        string result)
+    {
+        InputSelector = inputSelector;
+        Result = result;
+    }
+
+    internal static SwitchContext With(SwitchSelector inputSelector)
+        => new(inputSelector,
+            string.Empty);
+
+    internal SwitchContext With(string result)
+        => this.Tee(_ => _.Result = result);
+}

--- a/test/Switch/SwitchSelector.cs
+++ b/test/Switch/SwitchSelector.cs
@@ -6,5 +6,7 @@ public enum SwitchSelector
     North,
     South,
     West,
-    Est
+    East,
+    Error,
+    Exception
 }

--- a/test/Switch/SwitchUseCase.cs
+++ b/test/Switch/SwitchUseCase.cs
@@ -1,3 +1,14 @@
+using PipelineFp.Patterns;
+using PipelineFp.Pipelines;
+using PipelineFp.Steps;
+using PipelineFpTest.DataTypes;
+using PipelineFpTest.Switch.AsyncMatchingPipeline;
+using PipelineFpTest.Switch.ConditionalAsyncPipeline;
+using PipelineFpTest.Switch.ConditionalPipeline;
+using PipelineFpTest.Switch.MatchingPipeline;
+using TinyFp;
+using TinyFp.Extensions;
+
 namespace PipelineFpTest.Switch;
 
 public class SwitchUseCase
@@ -9,6 +20,134 @@ public class SwitchUseCase
             SwitchSelector.North => "North selector",
             SwitchSelector.South => "South selector",
             SwitchSelector.West => "West selector",
-            SwitchSelector.Est => "Est selector"
+            SwitchSelector.East => "Est selector"
         };
+
+
+    public static string ResolveUsingConditionalPipeline(SwitchSelector switchSelector)
+        => new List<IConditionalStep<Error, SwitchContext>>
+        {
+            new SwitchNoneConditionalStep(),
+            new SwitchNorthConditionalStep(),
+            new SwitchEastConditionalStep(),
+            new SwitchSouthConditionalStep(),
+            new SwitchWestConditionalStep(),
+        }
+        .Map(steps => SwitchContext
+                      .With(switchSelector)
+                      .Map(context => ConditionalPipeline<SwitchContext>
+                                      .Given(context)
+                                      .Fit(steps)))
+        .Match(_ => _.Result,
+               _ => string.Empty);
+
+    public static Task<string> ResolveUsingConditionalAsyncPipeline(SwitchSelector switchSelector)
+        => new List<IConditionalAsyncStep<Error, SwitchContext>>
+        {
+            new SwitchNoneConditionalAsyncStep(),
+            new SwitchNorthConditionalAsyncStep(),
+            new SwitchEastConditionalAsyncStep(),
+            new SwitchSouthConditionalAsyncStep(),
+            new SwitchWestConditionalAsyncStep(),
+        }
+        .Map(steps => SwitchContext
+                      .With(switchSelector)
+                      .Map(context => ConditionalPipeline<SwitchContext>
+                                      .Given(context)
+                                      .Fit(steps)))
+        .MatchAsync(_ => _.Result,
+               _ => string.Empty);
+
+    public static Task<string> ResolveUsingConditionalAsyncPipeline_WhenError(SwitchSelector switchSelector)
+        => new List<IConditionalAsyncStep<Error, SwitchContext>>
+        {
+            new SwitchNoneConditionalAsyncStep(),
+            new SwitchErrorConditionalAsyncStep(),
+            new SwitchNorthConditionalAsyncStep(),
+            new SwitchEastConditionalAsyncStep(),
+            new SwitchSouthConditionalAsyncStep(),
+            new SwitchWestConditionalAsyncStep(),
+        }
+        .Map(steps => SwitchContext
+                      .With(switchSelector)
+                      .Map(context => ConditionalPipeline<SwitchContext>
+                                      .Given(context)
+                                      .Fit(steps, [new SwitchOnErrorAsyncStep()], [])))
+        .MatchAsync(_ => _.Result,
+               _ => string.Empty);
+
+    public static Task<string> ResolveUsingConditionalAsyncPipeline_WhenErrorAndWithoutErrorSteps(SwitchSelector switchSelector)
+        => new List<IConditionalAsyncStep<Error, SwitchContext>>
+        {
+            new SwitchNoneConditionalAsyncStep(),
+            new SwitchErrorConditionalAsyncStep(),
+            new SwitchNorthConditionalAsyncStep(),
+            new SwitchEastConditionalAsyncStep(),
+            new SwitchSouthConditionalAsyncStep(),
+            new SwitchWestConditionalAsyncStep(),
+        }
+        .Map(steps => SwitchContext
+                      .With(switchSelector)
+                      .Map(context => ConditionalPipeline<SwitchContext>
+                                      .Given(context)
+                                      .Fit(steps, [], [])))
+        .MatchAsync(_ => _.Result,
+                    _ => _.Message);
+
+    public static Task<string> ResolveUsingConditionalAsyncPipeline_WhenException(SwitchSelector switchSelector)
+        => new List<IConditionalAsyncStep<Error, SwitchContext>>
+        {
+            new SwitchNoneConditionalAsyncStep(),
+            new SwitchExceptionConditionalAsyncStep(),
+            new SwitchNorthConditionalAsyncStep(),
+            new SwitchEastConditionalAsyncStep(),
+            new SwitchSouthConditionalAsyncStep(),
+            new SwitchWestConditionalAsyncStep(),
+        }
+        .Map(steps => SwitchContext
+                      .With(switchSelector)
+                      .Map(context => ConditionalPipeline<SwitchContext>
+                                      .Given(context)
+                                      .Fit(steps, [new SwitchOnErrorAsyncStep()], [new SwitchOnExceptionAsyncStep()])))
+        .MatchAsync(_ => _.Result,
+               _ => string.Empty);
+
+    public static string ResolveUsingPatternMatching(SwitchSelector switchSelector)
+        => new HashSet<IPattern<Error, SwitchPatternContext, SwitchSelector>>
+        {
+            new SwitchNonePattern(),
+            new SwitchNorthPattern(),
+            new SwitchSouthPattern(),
+            new SwitchEastPattern(),
+            new SwitchWestPattern(),
+            new SwitchErrorPattern(),
+            new SwitchExceptionPattern()
+        }
+        .Map(steps => SwitchPatternContext
+                      .With(switchSelector)
+                      .Map(context => MatchingPipeline<SwitchPatternContext, SwitchSelector>
+                                     .Given(context)
+                                     .Match(steps, [new SwitchOnError()], [new SwitchOnException()])))
+        .Match(_ => _.Result,
+               _ => string.Empty);
+
+    public static Task<string> ResolveUsingAsyncPatternMatching(SwitchSelector switchSelector)
+        => new HashSet<IAsyncPattern<Error, SwitchPatternAsyncContext, SwitchSelector>>
+        {
+            new SwitchNoneAsyncPattern(),
+            new SwitchNorthAsyncPattern(),
+            new SwitchSouthAsyncPattern(),
+            new SwitchEastAsyncPattern(),
+            new SwitchWestAsyncPattern(),
+            new SwitchErrorAsyncPattern(),
+            new SwitchExceptionAsyncPattern(),
+
+        }
+        .Map(steps => SwitchPatternAsyncContext
+                      .With(switchSelector)
+                      .Map(context => MatchingPipeline<SwitchPatternAsyncContext, SwitchSelector>
+                                     .Given(context)
+                                     .Match(steps, [new SwitchAsyncOnError()], [new SwitchAsyncOnException()])))
+        .MatchAsync(_ => _.Result,
+                    _ => string.Empty);
 }

--- a/test/Tests/BuilderStepsTests.cs
+++ b/test/Tests/BuilderStepsTests.cs
@@ -18,4 +18,96 @@ public class BuilderStepsTests
             .ResolveUsingIf(steps)
             .Should()
             .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Third")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Second,Third")]
+    public void WhenUsingAsyncPipeline_ResolveTheRightSteps(BuilderStep steps, string expected)
+    => BuilderUseCase
+    .ResolveUsingAsyncPipeline(steps)
+    .Result
+    .Should()
+    .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "Error Handled: TestError. Executed steps: First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Error Handled: TestError. Executed steps: Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Error Handled: TestError. Executed steps: ")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "Error Handled: TestError. Executed steps: First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Error Handled: TestError. Executed steps: Second")]
+    public void WhenUsingAsyncPipeline_WhenError_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingAsyncPipelineInCaseOfError(steps)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "TestError")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "TestError")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "TestError")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "TestError")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "TestError")]
+    public void WhenUsingAsyncPipeline_WhenError_AndNotErrorSteps_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingAsyncPipelineInCaseOfErrorWithoutErrorSteps(steps)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "Exception Handled: Exception. Executed steps: First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Exception Handled: Exception. Executed steps: Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Exception Handled: Exception. Executed steps: ")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "Exception Handled: Exception. Executed steps: First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Exception Handled: Exception. Executed steps: Second")]
+    public void WhenUsingAsyncPipeline_WhenException_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingAsyncPipelineInCaseOfException(steps)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Third")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Second,Third")]
+    public void WhenUsingPipeline_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingPipeline(steps)
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "Error Handled: TestError. Executed steps: First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Error Handled: TestError. Executed steps: Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Error Handled: TestError. Executed steps: ")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "Error Handled: TestError. Executed steps: First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Error Handled: TestError. Executed steps: Second")]
+    public void WhenUsingPipeline_WhenError_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingPipelineInCaseOfError(steps)
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "Exception Handled: Exception. Executed steps: First")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "Exception Handled: Exception. Executed steps: Second")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "Exception Handled: Exception. Executed steps: ")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "Exception Handled: Exception. Executed steps: First,Second")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "Exception Handled: Exception. Executed steps: Second")]
+    public void WhenUsingPipeline_WhenException_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingPipelineInCaseOfException(steps)
+        .Should()
+        .Be(expected);
+
+    [TestCase(BuilderStep.None | BuilderStep.First, "TestError")]
+    [TestCase(BuilderStep.None | BuilderStep.Second, "TestError")]
+    [TestCase(BuilderStep.None | BuilderStep.Third, "TestError")]
+    [TestCase(BuilderStep.First | BuilderStep.Second, "TestError")]
+    [TestCase(BuilderStep.Second | BuilderStep.Third, "TestError")]
+    public void WhenUsingPipeline_WhenError_AndNotErrorHandler_ResolveTheRightSteps(BuilderStep steps, string expected)
+        => BuilderUseCase
+        .ResolveUsingPipelineInCaseOfErrorWithoutErrorSteps(steps)
+        .Should()
+        .Be(expected);
 }

--- a/test/Tests/StrategyTests.cs
+++ b/test/Tests/StrategyTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using PipelineFpTest.Strategy;
+
+namespace PipelineFpTest.Tests;
+
+internal class StrategyTests
+{
+    [TestCase("first", "A")]
+    [TestCase("second", "B")]
+    [TestCase("third", "C")]
+    public void WhenUsingPatternMatching_ResolveTheRightStrategy(string selector, string expected)
+    => StrategyUseCase
+    .ResolveUsingPatternMatching(selector, ["A", "B", "C"])
+    .Should()
+    .Be(expected);
+
+    [TestCase("first", "First strategy error")]
+    [TestCase("second", "Second strategy error")]
+    [TestCase("third", "Third strategy error")]
+    public void WhenUsingPatternMatching_AndThereIsAnEror_ResolveTheRightStrategy(string selector, string expected)
+        => StrategyUseCase
+        .ResolveUsingPatternMatching(selector, [])
+        .Should()
+        .Be(expected);
+
+    [TestCase("first", "A")]
+    [TestCase("second", "B")]
+    [TestCase("third", "C")]
+    public void WhenUsingAsyncPatternMatching_ResolveTheRightStrategy(string selector, string expected)
+        => StrategyUseCase
+        .ResolveUsingAsyncPatternMatching(selector, ["A", "B", "C"])
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase("first", "First strategy error")]
+    [TestCase("second", "Second strategy error")]
+    [TestCase("third", "Third strategy error")]
+    public void WhenUsingAsyncPatternMatching_AndThereIsAnEror_ResolveTheRightStrategy(string selector, string expected)
+        => StrategyUseCase
+        .ResolveUsingAsyncPatternMatching(selector, [])
+        .Result
+        .Should()
+        .Be(expected);
+}

--- a/test/Tests/SwitchUseCaseTests.cs
+++ b/test/Tests/SwitchUseCaseTests.cs
@@ -10,10 +10,96 @@ public class SwitchUseCaseTests
     [TestCase(SwitchSelector.North, "North selector")]
     [TestCase(SwitchSelector.South, "South selector")]
     [TestCase(SwitchSelector.West, "West selector")]
-    [TestCase(SwitchSelector.Est, "Est selector")]
+    [TestCase(SwitchSelector.East, "Est selector")]
     public void WhenUsingSwitch_ResolveTheRightString(SwitchSelector selector, string expected)
         => new SwitchUseCase()
             .ResolveUsingSwitch(selector)
             .Should()
             .Be(expected);
+
+    [TestCase(SwitchSelector.None, "None selector")]
+    [TestCase(SwitchSelector.North, "North selector")]
+    [TestCase(SwitchSelector.South, "South selector")]
+    [TestCase(SwitchSelector.West, "West selector")]
+    [TestCase(SwitchSelector.East, "East selector")]
+    public void WhenUsingConditionalPipeline_ResolveTheRightString(SwitchSelector selector, string expected)
+    => SwitchUseCase
+    .ResolveUsingConditionalPipeline(selector)
+    .Should()
+    .Be(expected);
+
+    [TestCase(SwitchSelector.None, "None selector")]
+    [TestCase(SwitchSelector.North, "North selector")]
+    [TestCase(SwitchSelector.South, "South selector")]
+    [TestCase(SwitchSelector.West, "West selector")]
+    [TestCase(SwitchSelector.East, "East selector")]
+    public void WhenUsingAsyncPipeline_ResolveTheRightString(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingConditionalAsyncPipeline(selector)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(SwitchSelector.None, "Error Handled: Error")]
+    [TestCase(SwitchSelector.North, "Error Handled: Error")]
+    [TestCase(SwitchSelector.South, "Error Handled: Error")]
+    [TestCase(SwitchSelector.West, "Error Handled: Error")]
+    [TestCase(SwitchSelector.East, "Error Handled: Error")]
+    public void WhenUsingAsyncPipeline_AndError_ReturnError(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingConditionalAsyncPipeline_WhenError(selector)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(SwitchSelector.None, "Error")]
+    [TestCase(SwitchSelector.North, "Error")]
+    [TestCase(SwitchSelector.South, "Error")]
+    [TestCase(SwitchSelector.West, "Error")]
+    [TestCase(SwitchSelector.East, "Error")]
+    public void WhenUsingAsyncPipeline_AndError_AndWithoutErrorHandlingSteps_ReturnError(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingConditionalAsyncPipeline_WhenErrorAndWithoutErrorSteps(selector)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(SwitchSelector.None, "Exception Handled: Exception")]
+    [TestCase(SwitchSelector.North, "Exception Handled: Exception")]
+    [TestCase(SwitchSelector.South, "Exception Handled: Exception")]
+    [TestCase(SwitchSelector.West, "Exception Handled: Exception")]
+    [TestCase(SwitchSelector.East, "Exception Handled: Exception")]
+    public void WhenUsingAsyncPipeline_AndError_ReturnException(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingConditionalAsyncPipeline_WhenException(selector)
+        .Result
+        .Should()
+        .Be(expected);
+
+    [TestCase(SwitchSelector.None, "None")]
+    [TestCase(SwitchSelector.North, "North")]
+    [TestCase(SwitchSelector.South, "South")]
+    [TestCase(SwitchSelector.West, "West")]
+    [TestCase(SwitchSelector.East, "East")]
+    [TestCase(SwitchSelector.Error, "Error")]
+    [TestCase(SwitchSelector.Exception, "Exception")]
+    public void WhenUsingPatternMatching_ResolveTheRightString(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingPatternMatching(selector)
+        .Should()
+        .Be(expected);
+
+    [TestCase(SwitchSelector.None, "None")]
+    [TestCase(SwitchSelector.North, "North")]
+    [TestCase(SwitchSelector.South, "South")]
+    [TestCase(SwitchSelector.West, "West")]
+    [TestCase(SwitchSelector.East, "East")]
+    [TestCase(SwitchSelector.Error, "Error")]
+    [TestCase(SwitchSelector.Exception, "Exception")]
+    public void WhenUsingAsyncPatternMatching_ResolveTheRightString(SwitchSelector selector, string expected)
+        => SwitchUseCase
+        .ResolveUsingAsyncPatternMatching(selector)
+        .Result
+        .Should()
+        .Be(expected);
 }

--- a/test/pipeline-fp-test.csproj
+++ b/test/pipeline-fp-test.csproj
@@ -15,7 +15,6 @@
 		</PackageReference>
 
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<ProjectReference Include="../src/pipeline-fp.csproj" />
 
 		<PackageReference Include="nunit" Version="4.0.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -23,6 +22,10 @@
 		<PackageReference Include="Moq" Version="4.20.70" />
 
 
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\src\pipeline-fp.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add src and test for three different pipelines, that are, the basic `Pipeline`, that implements a template-ish pattern, a Rule-engine-like pipeline, the `ConditionalPipeline` and a pattern-matching strategy-factory one, the `MatchingPipeline`.

On top of this, add tests to cover the majority of the code and use cases.

Slightly change the Readme file and a CI that runs on pull-requests into main